### PR TITLE
Properly set NVariations in ResponselessParamUtility

### DIFF
--- a/src/systematicstools/utility/ResponselessParamUtility.cc
+++ b/src/systematicstools/utility/ResponselessParamUtility.cc
@@ -30,6 +30,9 @@ void FinalizeAndValidateDependentParameters(
             << std::quoted(resp_hdr.prettyName) << " is configured with "
             << NVariations << " variations.";
       }
+      else{
+        NVariations = hdr.paramVariations.size();
+      }
     }
   }
 


### PR DESCRIPTION
This is a copy of https://github.com/LArSoft/systematicstools/pull/2; to set `NVariations` from the first entry of for loop. 